### PR TITLE
Support various types of formatting in the list command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ EMAIL = 'brian@pythontesting.net'
 AUTHOR = 'Brian Okken'
 REQUIRES_PYTHON = '>=3.6.0'
 
-REQUIRED = [ 'click', 'tinydb', 'attrs' ]
+REQUIRED = ['click', 'tinydb', 'attrs', 'tabulate']
 
 # The rest you shouldn't have to touch too much :)
 # ------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import io
 import os
 import re
 
-from setuptools import find_packages, setup, Command
+from setuptools import find_packages, setup
 
 # Package meta-data.
 NAME = 'cards'
@@ -28,9 +28,11 @@ here = os.path.abspath(os.path.dirname(__file__))
 with io.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = '\n' + f.read()
 
+
 def read(*parts):
     with io.open(os.path.join(here, *parts), 'r') as fp:
         return fp.read()
+
 
 def find_version(*file_paths):
     version_file = read(*file_paths)
@@ -39,7 +41,6 @@ def find_version(*file_paths):
     if version_match:
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
-
 
 
 setup(

--- a/src/cards/cli.py
+++ b/src/cards/cli.py
@@ -1,9 +1,12 @@
 """Command Line Interface (CLI) for cards project."""
 
+import os
 import click
 import cards
 import pathlib
 from tabulate import tabulate
+
+DEFAULT_TABLEFORMAT = os.environ.get('CARDSTABLEFORMAT', 'simple')
 
 
 @click.group(invoke_without_command=True,
@@ -40,10 +43,10 @@ def delete(card_id):
 @click.option('-d', '--done', default=None,
               type=bool,
               help='filter on cards with given done state')
-@click.option('--tableformat', default=None,
+@click.option('--tableformat', default=DEFAULT_TABLEFORMAT,
               type=str,
               help='table formatting option, eg. "grid", "simple", "html"')
-def list_cards(noowner, owner, done, tableformat='grid'):
+def list_cards(noowner, owner, done, tableformat):
     """
     List cards in db.
     """

--- a/src/cards/cli.py
+++ b/src/cards/cli.py
@@ -3,6 +3,7 @@
 import click
 import cards
 import pathlib
+from tabulate import tabulate
 
 
 @click.group(invoke_without_command=True,
@@ -39,17 +40,21 @@ def delete(card_id):
 @click.option('-d', '--done', default=None,
               type=bool,
               help='filter on cards with given done state')
-def list_cards(noowner, owner, done):
+@click.option('--tableformat', default=None,
+              type=str,
+              help='table formatting option, eg. "grid", "simple", "html"')
+def list_cards(noowner, owner, done, tableformat='grid'):
     """
     List cards in db.
     """
-    formatstr = "{: >4} {: >10} {: >5} {}"
-    print(formatstr.format('ID', 'owner', 'done', 'summary'))
-    print(formatstr.format('--', '-----', '----', '-------'))
+    items = []
     for t in cards_db().list_cards(noowner, owner, done):
         done = ' x ' if t.done else ''
         owner = '' if t.owner is None else t.owner
-        print(formatstr.format(t.id, owner, done, t.summary))
+        items.append((t.id, owner, done, t.summary))
+    print(tabulate(items,
+                   headers=('ID', 'owner', 'done', 'summary'),
+                   tablefmt=tableformat))
 
 
 @cards_cli.command(help="update card")

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -6,5 +6,6 @@ def detabulate_output(output):
     lines = output.split('\n')
     headers = lines[0].split('||')
     headers = [header.strip() for header in headers[1:-1]]
-    values = [[item.strip() for item in row.split('|')[1:-1]] for row in lines[1:]]
+    values = [[item.strip()
+               for item in row.split('|')[1:-1]] for row in lines[1:]]
     return headers, values

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,0 +1,10 @@
+def detabulate_output(output):
+    """
+    Turn a tabulate output into a tuple of headers and rows
+    assuming the output was formatted in the "jira" style
+    """
+    lines = output.split('\n')
+    headers = lines[0].split('||')
+    headers = [header.strip() for header in headers[1:-1]]
+    values = [[item.strip() for item in row.split('|')[1:-1]] for row in lines[1:]]
+    return headers, values

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -57,7 +57,8 @@ def test_list_filter(db_empty, runner):
 
     # `cards --noowner -o okken -d True` should return two items
     result = runner.invoke(cards.cli.cards_cli,
-                           ['list', '--noowner', '-o', 'okken', '-d', 'True', '--tableformat=jira'])
+                           ['list', '--noowner', '-o', 'okken',
+                            '-d', 'True', '--tableformat=jira'])
     headers, items = detabulate_output(result.output)
     assert headers == ['ID', 'owner', 'done', 'summary']
     assert items[0][0] == '3'

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -19,7 +19,7 @@ def test_add(db_empty, runner):
     runner.invoke(cards.cli.cards_cli, ['add', 'something'])
 
     # THEN The listing returns just the new card
-    result = runner.invoke(cards.cli.cards_cli, ['list'])
+    result = runner.invoke(cards.cli.cards_cli, ['list', '--tableformat=simple'])
     expected_output = ("  ID      owner  done summary\n"
                        "  --      -----  ---- -------\n"
                        "   1                  something\n")
@@ -33,7 +33,7 @@ def test_list(db_empty, runner):
     runner.invoke(cards.cli.cards_cli, ['add', 'two'])
 
     # `cards list` returns our 2 cards
-    result = runner.invoke(cards.cli.cards_cli, ['list'])
+    result = runner.invoke(cards.cli.cards_cli, ['list', '--tableformat=simple'])
     expected = ("  ID      owner  done summary\n"
                 "  --      -----  ---- -------\n"
                 "   1                  one\n"
@@ -57,7 +57,7 @@ def test_list_filter(db_empty, runner):
 
     # `cards --noowner -o okken -d True` should return two items
     result = runner.invoke(cards.cli.cards_cli,
-                           ['list', '--noowner', '-o', 'okken', '-d', 'True'])
+                           ['list', '--noowner', '-o', 'okken', '-d', 'True', '--tableformat=simple'])
     expected = ("  ID      owner  done summary\n"
                 "  --      -----  ---- -------\n"
                 "   3      okken    x  three\n"
@@ -82,7 +82,7 @@ def test_count(db_empty, runner):
 @pytest.mark.smoke
 def test_update(db_non_empty, runner):
     # GIVEN a card known to be in the db
-    result = runner.invoke(cards.cli.cards_cli, ['list'])
+    result = runner.invoke(cards.cli.cards_cli, ['list', '--tableformat=simple'])
 
     # this is kinda tricky
     last_item_as_list = result.output.split('\n')[-2].split()
@@ -94,7 +94,7 @@ def test_update(db_non_empty, runner):
                   ['update', '-o', 'okken', '-d', 'True', orig_id])
 
     # THEN `cards list` will show the changes
-    result = runner.invoke(cards.cli.cards_cli, ['list'])
+    result = runner.invoke(cards.cli.cards_cli, ['list', '--tableformat=simple'])
     last_item_as_list = result.output.split('\n')[-2].split()
     id = last_item_as_list[0]
     owner = last_item_as_list[1]
@@ -117,7 +117,7 @@ def test_delete(db_empty, runner):
     runner.invoke(cards.cli.cards_cli, ['delete', '1'])
 
     # THEN the other card remains in the db
-    result = runner.invoke(cards.cli.cards_cli, ['list'])
+    result = runner.invoke(cards.cli.cards_cli, ['list', '--tableformat=simple'])
     expected = ("  ID      owner  done summary\n"
                 "  --      -----  ---- -------\n"
                 "   2                  two\n")

--- a/tests/cli/test_cli_alac.py
+++ b/tests/cli/test_cli_alac.py
@@ -15,6 +15,7 @@ Cons:
 
 import pytest
 from cards.cli import cards_cli
+from . import detabulate_output
 
 
 pytestmark = pytest.mark.cli
@@ -40,52 +41,37 @@ def test_alac_1(db_empty, runner):
     runner.invoke(cards_cli, ['add', 'Foo Bar Baz'])
 
     # 2. Make sure they show up in the list.
-    result = runner.invoke(cards_cli, ['list'])
-    expected = ("  ID      owner  done summary\n"
-                "  --      -----  ---- -------\n"
-                "   1                  something\n"
-                "   2      okken       something else\n"
-                "   3                  Foo Bar Baz\n")
-    assert expected == result.output
+    result = runner.invoke(cards_cli, ['list', '--tableformat=jira'])
+    headers, items = detabulate_output(result.output)
+    assert headers == ['ID', 'owner', 'done', 'summary']
+    assert items[0] == ['1', '', '', 'something']
+    assert items[1] == ['2', 'okken', '', 'something else']
+    assert items[2] == ['3', '', '', 'Foo Bar Baz']
+
 
     # 3. Change the owner on a card. Verify change.
     runner.invoke(cards_cli, ['update', '1', '-o', 'okken'])
-    result = runner.invoke(cards_cli, ['list'])
-    expected = ("  ID      owner  done summary\n"
-                "  --      -----  ---- -------\n"
-                "   1      okken       something\n"
-                "   2      okken       something else\n"
-                "   3                  Foo Bar Baz\n")
-    assert expected == result.output
+    result = runner.invoke(cards_cli, ['list', '--tableformat=jira'])
+    headers, items = detabulate_output(result.output)
+    assert items[0] == ['1', 'okken', '', 'something']
 
     # 4. Change the done state on a card. Verify change.
     runner.invoke(cards_cli, ['update', '2', '-d', 'True'])
-    result = runner.invoke(cards_cli, ['list'])
-    expected = ("  ID      owner  done summary\n"
-                "  --      -----  ---- -------\n"
-                "   1      okken       something\n"
-                "   2      okken    x  something else\n"
-                "   3                  Foo Bar Baz\n")
-    assert expected == result.output
+    result = runner.invoke(cards_cli, ['list', '--tableformat=jira'])
+    headers, items = detabulate_output(result.output)
+    assert items[1] == ['2', 'okken', 'x', 'something else']
 
     # 5. Change the sumary on a card. Verify change.
     runner.invoke(cards_cli, ['update', '3', '-s', 'just sit'])
-    result = runner.invoke(cards_cli, ['list'])
-    expected = ("  ID      owner  done summary\n"
-                "  --      -----  ---- -------\n"
-                "   1      okken       something\n"
-                "   2      okken    x  something else\n"
-                "   3                  just sit\n")
-    assert expected == result.output
+    result = runner.invoke(cards_cli, ['list', '--tableformat=jira'])
+    headers, items = detabulate_output(result.output)
+    assert items[2] == ['3', '', '', 'just sit']
 
     # 6. Delete the done item. Verify change.
     runner.invoke(cards_cli, ['delete', '2'])
-    result = runner.invoke(cards_cli, ['list'])
-    expected = ("  ID      owner  done summary\n"
-                "  --      -----  ---- -------\n"
-                "   1      okken       something\n"
-                "   3                  just sit\n")
-    assert expected == result.output
+    result = runner.invoke(cards_cli, ['list', '--tableformat=jira'])
+    headers, items = detabulate_output(result.output)
+    assert ['2', 'okken', 'x', 'something'] not in items
 
     # let's also check the count
     result = runner.invoke(cards_cli, ['count'])

--- a/tests/cli/test_cli_alac.py
+++ b/tests/cli/test_cli_alac.py
@@ -48,7 +48,6 @@ def test_alac_1(db_empty, runner):
     assert items[1] == ['2', 'okken', '', 'something else']
     assert items[2] == ['3', '', '', 'Foo Bar Baz']
 
-
     # 3. Change the owner on a card. Verify change.
     runner.invoke(cards_cli, ['update', '1', '-o', 'okken'])
     result = runner.invoke(cards_cli, ['list', '--tableformat=jira'])

--- a/tests/cli/test_cli_design.py
+++ b/tests/cli/test_cli_design.py
@@ -16,11 +16,11 @@ def test_list_on_no_command(db_non_empty, runner):
     output_with_list = runner.invoke(cards.cli.cards_cli, ['list']).output
     output_without_list = runner.invoke(cards.cli.cards_cli).output
 
-    expected_output = ("  ID      owner  done summary\n"
-                       "  --      -----  ---- -------\n"
-                       "   1                  first item\n"
-                       "   2                  second item\n"
-                       "   3                  third item\n")
+    expected_output = ("  ID  owner    done    summary\n"
+                       "----  -------  ------  -----------\n"
+                       "   1                   first item\n"
+                       "   2                   second item\n"
+                       "   3                   third item\n")
     assert expected_output == output_with_list
     assert expected_output == output_without_list
     assert output_with_list == output_without_list


### PR DESCRIPTION
# Overview
This change moves the formatting of the list output into a 3rd party package (tabulate) which benefits from "pretty grids" and also the option to output as html.

## Changes to tests
Since the tests were bound to the exact padding of the formatstring in the current code, I've created a simple method within the test submodule that turns the output into a collection of nested lists and makes it easier to assert against (and update in future).

### Why?
I thought that many of the tests were testing the padding of the table, should some, say change one of the headings, all the tests would need to change. 
Also, when people add tests to projects they contribute to, they _tend_ to copy+paste the original author's test patterns. So whilst it may not be a big piece of tech debt now, it could become so quickly.

There is 1 exception where the formatting is left untouched, `test_cli_design`, which tests the actual output of the default formatter and therefore checks all of the other scenarios checked off.

# New design
By default, the new design will look _very_ similar to the old, but the table header (the line under the headings) will automatically pad itself to the longest value in the column.

You can set the tableformat to grid, "jira" (for putting into JIRA) or "html" for outputting HTML.

```
(env) anthonyshaw ~/repo/cards table_formatting $ cards list
  ID  owner    done    summary
----  -------  ------  -----------
   1                   do homework
(env) anthonyshaw ~/repo/cards table_formatting $ cards list --tableformat=html
<table>
<thead>
<tr><th style="text-align: right;">  ID</th><th>owner  </th><th>done  </th><th>summary    </th></tr>
</thead>
<tbody>
<tr><td style="text-align: right;">   1</td><td>       </td><td>      </td><td>do homework</td></tr>
</tbody>
</table>
(env) anthonyshaw ~/repo/cards table_formatting $ cards list --tableformat=grid
+------+---------+--------+-------------+
|   ID | owner   | done   | summary     |
+======+=========+========+=============+
|    1 |         |        | do homework |
+------+---------+--------+-------------+
```

# Setting default format

Should the default not satisfy your needs, you can use the `CARDSTABLEFORMAT` environment variable to ensure any call will use (unless overriden with CLI flag) your desired choice

```
(env) anthonyshaw ~/repo/cards table_formatting $ cards list
  ID  owner    done    summary
----  -------  ------  -----------
   1                   do homework
(env) anthonyshaw ~/repo/cards table_formatting $ $CARDSTABLEFORMAT='grid'
(env) anthonyshaw ~/repo/cards table_formatting $ cards list
+------+---------+--------+-------------+
|   ID | owner   | done   | summary     |
+======+=========+========+=============+
|    1 |         |        | do homework |
+------+---------+--------+-------------+
```