### PR TITLE
Update travis python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,20 @@ language: python
 python:
 - 3.6
 - 3.6-dev
-- 3.7-dev
+
+matrix:
+include:
+  - python: 3.7
+    env: TOXENV=py37
+    dist: xenial      # required for Python 3.7 (travis-ci/travis-ci#9069)
+    sudo: required    # required for Python 3.7 (travis-ci/travis-ci#9069)
+  - python: nightly
+    env: TOXENV=py38
+    dist: xenial      # required for Python 3.8 (travis-ci/travis-ci#9069)
+    sudo: required    # required for Python 3.8 (travis-ci/travis-ci#9069)
+allow_failures:
+  - python: nightly
+
 
 install:
 - pip install -U tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 matrix:
   include:
     - python: 3.6
+      env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
       dist: xenial      # required for Python 3.7 (travis-ci/travis-ci#9069)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
       env: TOXENV=py38
       dist: xenial      # required for Python 3.8 (travis-ci/travis-ci#9069)
       sudo: required    # required for Python 3.8 (travis-ci/travis-ci#9069)
+    - python: 3.6
+      env: TOXENV=flake8
   allow_failures:
     - python: nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 language: python
 
 matrix:
-include:
-  - python: 3.6
-  - python: 3.7
-    env: TOXENV=py37
-    dist: xenial      # required for Python 3.7 (travis-ci/travis-ci#9069)
-    sudo: required    # required for Python 3.7 (travis-ci/travis-ci#9069)
-  - python: nightly
-    env: TOXENV=py38
-    dist: xenial      # required for Python 3.8 (travis-ci/travis-ci#9069)
-    sudo: required    # required for Python 3.8 (travis-ci/travis-ci#9069)
-allow_failures:
-  - python: nightly
+  include:
+    - python: 3.6
+    - python: 3.7
+      env: TOXENV=py37
+      dist: xenial      # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required    # required for Python 3.7 (travis-ci/travis-ci#9069)
+    - python: nightly
+      env: TOXENV=py38
+      dist: xenial      # required for Python 3.8 (travis-ci/travis-ci#9069)
+      sudo: required    # required for Python 3.8 (travis-ci/travis-ci#9069)
+  allow_failures:
+    - python: nightly
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: python
 
-python:
-- 3.6
-- 3.6-dev
-
 matrix:
 include:
+  - python: 3.6
+  - python: 3.6-dev
   - python: 3.7
     env: TOXENV=py37
     dist: xenial      # required for Python 3.7 (travis-ci/travis-ci#9069)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 matrix:
 include:
   - python: 3.6
-  - python: 3.6-dev
   - python: 3.7
     env: TOXENV=py37
     dist: xenial      # required for Python 3.7 (travis-ci/travis-ci#9069)

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     coverage-erase,
     py36,
     py37,
+    py38,
     coverage-report,
     flake8
 
@@ -11,8 +12,6 @@ skip_missing_interpreters = true
 [travis]
 python =
     3.6: py36
-    3.6-dev: py36
-    3.7-dev: py37
 
 [testenv:coverage-erase]
 skip_install = true


### PR DESCRIPTION
Updated the include python 3.7 and the currently nightly build, effectively, the latest 3.8-dev. I also set the nightly as allowed to fail so as to not fail the overall travis build.

I also cleaned up 3.6-dev as it's pulling 3.6.5, so not much good considering 3.6.7 is out. I'm not sure how much travis-ci keep up the -dev builds for the older versions.