### PR TITLE
Travis CI is depricating the use of 'sudo'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,13 @@ matrix:
     - python: 3.7
       env: TOXENV=py37
       dist: xenial      # required for Python 3.7 (travis-ci/travis-ci#9069)
-      sudo: required    # required for Python 3.7 (travis-ci/travis-ci#9069)
     - python: nightly
       env: TOXENV=py38
       dist: xenial      # required for Python 3.8 (travis-ci/travis-ci#9069)
-      sudo: required    # required for Python 3.8 (travis-ci/travis-ci#9069)
     - python: 3.6
       env: TOXENV=flake8
   allow_failures:
     - python: nightly
-
 
 install:
 - pip install -U tox-travis


### PR DESCRIPTION
[Travis are now recommending removing '__sudo__'](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)