### PR TITLE
.pre-commit-config.yaml: Add codespell

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,17 @@
+# https://pre-commit.com
+# This GitHub Action assumes that the repo contains a valid .pre-commit-config.yaml file.
+name: pre-commit
+on:
+  pull_request:
+  push:
+    branches: [master]
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+      - run: pip install pre-commit
+      - run: pre-commit --version
+      - run: pre-commit install
+      - run: pre-commit run --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,7 +9,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
       - uses: actions/setup-python@v1
       - run: pip install pre-commit
       - run: pre-commit --version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,12 @@ repos:
     rev: stable
     hooks:
       - id: black
+  - repo: https://github.com/codespell-project/codespell
+    rev: v1.16.0
+    hooks:
+      - id: codespell
+        args:
+          - --quiet-level=2
   - repo: https://github.com/pycqa/flake8
     rev: 3.7.9
     hooks:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,7 +26,7 @@ Commands:
   update  update card
 ```
 
-To get help on the commands options and arguements use `cards [command] --help`.
+To get help on the commands options and arguments use `cards [command] --help`.
 
 Here are a few...
 


### PR DESCRIPTION
Fixes #42

1. Commit 1 Add [__codespell__](https://github.com/codespell-project/codespell) to pre-commit.yaml -- CI tests are not run :-(
    * It unsafe to assume that outside contributors have pre-commit properly installed.
2. Commit 2 Add a GitHub Action to run this repo's pre-commit on all incoming PRs -- ❌ 
    * Trust but verify
3. Commit 3 Fix typo discovered by codespell -- ✅ 