### PR TITLE
pre-commit autoupdate ; pre-commit run --all-files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
       - name: Install Tox and any other packages
         run: pip install tox
       - name: Run Tox

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v4.4.0
     hooks:
     -   id: check-added-large-files
     -   id: check-builtin-literals
@@ -14,31 +14,31 @@ repos:
     -   id: mixed-line-ending
     -   id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 23.7.0
     hooks:
       - id: black
   - repo: https://github.com/codespell-project/codespell
-    rev: v1.16.0
+    rev: v2.2.5
     hooks:
       - id: codespell
         args:
           - --quiet-level=2
   - repo: https://github.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 6.1.0
     hooks:
     -   id: flake8
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v1.9.0
+    rev: v3.10.0
     hooks:
     -   id: reorder-python-imports
         args: [--py3-plus]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.0.1
+    rev: v3.10.1
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
   - repo: https://github.com/asottile/add-trailing-comma
-    rev: v1.5.0
+    rev: v3.1.0
     hooks:
     - id: add-trailing-comma
       args: [--py36-plus]

--- a/README.md
+++ b/README.md
@@ -78,4 +78,3 @@ for details, but here\'s a demo of how it works:
       start    Set a card state to 'in prog'.
       update   Modify a card in db with given id with new info.
       version  Return version of cards application
-

--- a/src/cards/api.py
+++ b/src/cards/api.py
@@ -76,13 +76,9 @@ class CardsDB:
                 if (t["owner"] == owner and t["state"] == state)
             ]
         elif owner is not None:
-            return [
-                Card.from_dict(t) for t in all_cards if t["owner"] == owner
-            ]
+            return [Card.from_dict(t) for t in all_cards if t["owner"] == owner]
         elif state is not None:
-            return [
-                Card.from_dict(t) for t in all_cards if t["state"] == state
-            ]
+            return [Card.from_dict(t) for t in all_cards if t["state"] == state]
         else:
             return [Card.from_dict(t) for t in all_cards]
 

--- a/src/cards/cli.py
+++ b/src/cards/cli.py
@@ -1,13 +1,14 @@
 """Command Line Interface (CLI) for cards project."""
 import os
-from io import StringIO
 import pathlib
-import rich
-from rich.table import Table
 from contextlib import contextmanager
+from io import StringIO
 from typing import List
+
 import cards
+import rich
 import typer
+from rich.table import Table
 
 
 app = typer.Typer(add_completion=False)
@@ -20,9 +21,7 @@ def version():
 
 
 @app.command()
-def add(
-    summary: List[str], owner: str = typer.Option(None, "-o", "--owner")
-):
+def add(summary: List[str], owner: str = typer.Option(None, "-o", "--owner")):
     """Add a card to db."""
     summary = " ".join(summary) if summary else None
     with cards_db() as db:
@@ -72,9 +71,7 @@ def update(
     summary = " ".join(summary) if summary else None
     with cards_db() as db:
         try:
-            db.update_card(
-                card_id, cards.Card(summary, owner, state=None)
-            )
+            db.update_card(card_id, cards.Card(summary, owner, state=None))
         except cards.InvalidCardId:
             print(f"Error: Invalid card id {card_id}")
 

--- a/src/cards/db.py
+++ b/src/cards/db.py
@@ -1,16 +1,12 @@
 """
 DB for the cards project
 """
-
-
 import tinydb
 
 
 class DB:
     def __init__(self, db_path, db_file_prefix):
-        self._db = tinydb.TinyDB(
-            db_path / f"{db_file_prefix}.json", create_dirs=True
-        )
+        self._db = tinydb.TinyDB(db_path / f"{db_file_prefix}.json", create_dirs=True)
 
     def create(self, item: dict) -> int:
         id = self._db.insert(item)

--- a/tests/api/test_add.py
+++ b/tests/api/test_add.py
@@ -7,7 +7,9 @@ Test Cases
 * `add` a duplicate card
 """
 import pytest
-from cards import Card, MissingSummary
+from cards import Card
+from cards import MissingSummary
+
 
 def test_add_from_empty(cards_db):
     """
@@ -29,6 +31,7 @@ def test_add_from_nonempty(cards_db):
     assert cards_db.count() == 4
     assert cards_db.get_card(i) == c
 
+
 def test_add_with_summary_and_owner(cards_db):
     """
     count should be 1 and card retrievable
@@ -38,6 +41,7 @@ def test_add_with_summary_and_owner(cards_db):
     assert cards_db.count() == 1
     assert cards_db.get_card(i) == c
 
+
 def test_add_missing_summary(cards_db):
     """
     Should raise an exception
@@ -45,6 +49,7 @@ def test_add_missing_summary(cards_db):
     c = Card()
     with pytest.raises(MissingSummary):
         cards_db.add_card(c)
+
 
 def test_add_duplicate(cards_db):
     """

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -2,5 +2,7 @@
 Test Cases
 * `config` returns the correct database path
 """
+
+
 def test_config(cards_db, db_path):
     assert cards_db.path() == db_path

--- a/tests/api/test_count.py
+++ b/tests/api/test_count.py
@@ -10,9 +10,11 @@ import pytest
 def test_count_no_cards(cards_db):
     assert cards_db.count() == 0
 
+
 @pytest.mark.num_cards(1)
 def test_count_one_card(cards_db):
     assert cards_db.count() == 1
+
 
 @pytest.mark.num_cards(3)
 def test_count_three_cards(cards_db):

--- a/tests/api/test_delete.py
+++ b/tests/api/test_delete.py
@@ -5,14 +5,17 @@ Test Cases:
 * `delete` a non-existent card
 """
 import pytest
-from cards import Card, InvalidCardId
+from cards import Card
+from cards import InvalidCardId
+
 
 @pytest.fixture()
 def three_cards(cards_db):
     i = cards_db.add_card(Card("foo"))
     j = cards_db.add_card(Card("bar"))
     k = cards_db.add_card(Card("baz"))
-    return (i, j, k) # ids for the cards
+    return (i, j, k)  # ids for the cards
+
 
 def test_delete_from_many(cards_db, three_cards):
     """
@@ -20,7 +23,7 @@ def test_delete_from_many(cards_db, three_cards):
     And card shouldn't be retrievable.
     But the rest should be.
     """
-    (i, j, k) = three_cards # ids
+    (i, j, k) = three_cards  # ids
     id_to_delete = j
     ids_still_there = (i, k)
 

--- a/tests/api/test_finish.py
+++ b/tests/api/test_finish.py
@@ -4,7 +4,8 @@ Test Cases
 * `finish` an invalid id
 """
 import pytest
-from cards import Card, InvalidCardId
+from cards import Card
+from cards import InvalidCardId
 
 
 @pytest.mark.parametrize("start_state", ("todo", "in prog", "done"))

--- a/tests/api/test_list.py
+++ b/tests/api/test_list.py
@@ -6,13 +6,14 @@ Test Cases
 import pytest
 from cards import Card
 
+
 def test_list_no_cards(cards_db):
     """Empty db, empty list"""
     assert cards_db.list_cards() == []
 
 
 def test_list_several_cards(cards_db):
-    """"
+    """ "
     Given a variety of cards, make sure they get returned.
     """
     orig = [
@@ -30,25 +31,28 @@ def test_list_several_cards(cards_db):
     for c in orig:
         assert c in the_list
 
+
 # list filter
 # - no owner
 # - specific owner
 # - specific state
 # - owner and state
 
+
 @pytest.fixture()
 def known_set():
-    return [Card(summary="zero", owner="Brian", state="todo"),
-            Card(summary="one", owner="Brian", state="in prog"),
-            Card(summary="two", owner="Brian", state="done"),
+    return [
+        Card(summary="zero", owner="Brian", state="todo"),
+        Card(summary="one", owner="Brian", state="in prog"),
+        Card(summary="two", owner="Brian", state="done"),
+        Card(summary="three", owner="Okken", state="todo"),
+        Card(summary="four", owner="Okken", state="in prog"),
+        Card(summary="five", owner="Okken", state="done"),
+        Card(summary="six", state="todo"),
+        Card(summary="seven", state="in prog"),
+        Card(summary="eight", state="done"),
+    ]
 
-            Card(summary="three", owner="Okken", state="todo"),
-            Card(summary="four", owner="Okken", state="in prog"),
-            Card(summary="five", owner="Okken", state="done"),
-
-            Card(summary="six", state="todo"),
-            Card(summary="seven", state="in prog"),
-            Card(summary="eight", state="done")]
 
 @pytest.fixture()
 def db_filled(cards_db, known_set):
@@ -56,18 +60,22 @@ def db_filled(cards_db, known_set):
         cards_db.add_card(c)
     return cards_db
 
-@pytest.mark.parametrize('owner_, state_, expected_indices', [
-    ("", None, (6, 7, 8)),
-    ("Brian", None, (0, 1, 2)),
-    ("Okken", None, (3, 4, 5)),
-    (None, "todo", (0, 3, 6)),
-    (None, "in prog", (1, 4, 7)),
-    (None, "done", (2, 5, 8)),
-    ("Brian", "todo", (0,)),
-], ids=str)
+
+@pytest.mark.parametrize(
+    "owner_, state_, expected_indices",
+    [
+        ("", None, (6, 7, 8)),
+        ("Brian", None, (0, 1, 2)),
+        ("Okken", None, (3, 4, 5)),
+        (None, "todo", (0, 3, 6)),
+        (None, "in prog", (1, 4, 7)),
+        (None, "done", (2, 5, 8)),
+        ("Brian", "todo", (0,)),
+    ],
+    ids=str,
+)
 def test_list_filter(db_filled, known_set, owner_, state_, expected_indices):
     result = db_filled.list_cards(owner=owner_, state=state_)
     assert len(result) == len(expected_indices)
     for i in expected_indices:
         assert known_set[i] in result
-

--- a/tests/api/test_start.py
+++ b/tests/api/test_start.py
@@ -4,7 +4,8 @@ Test Cases
 * `start` an invalid id
 """
 import pytest
-from cards import Card, InvalidCardId
+from cards import Card
+from cards import InvalidCardId
 
 
 @pytest.mark.parametrize("start_state", ("todo", "in prog", "done"))

--- a/tests/api/test_update.py
+++ b/tests/api/test_update.py
@@ -6,7 +6,8 @@ Test Cases
 * `update` a non-existent card
 """
 import pytest
-from cards import Card, InvalidCardId
+from cards import Card
+from cards import InvalidCardId
 
 
 def test_update_owner(cards_db):

--- a/tests/api/test_version.py
+++ b/tests/api/test_version.py
@@ -3,6 +3,7 @@ Test Cases
 * `version` returns the correct version
 """
 import re
+
 import cards
 
 

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,9 +1,11 @@
-from typer.testing import CliRunner
-import cards
-import pytest
 import shlex
 
+import cards
+import pytest
+from typer.testing import CliRunner
+
 runner = CliRunner()
+
 
 @pytest.fixture()
 def cards_cli_no_redirect():
@@ -12,7 +14,9 @@ def cards_cli_no_redirect():
         result = runner.invoke(cards.cli.app, command_list)
         output = result.stdout.rstrip()
         return output
+
     return run_cli
+
 
 @pytest.fixture()
 def cards_cli(cards_cli_no_redirect, db_path, monkeypatch, cards_db):

--- a/tests/cli/test_add.py
+++ b/tests/cli/test_add.py
@@ -1,5 +1,6 @@
 import cards
 
+
 def test_add(cards_db, cards_cli):
     cards_cli("add some task")
     expected = cards.Card("some task", owner="", state="todo")

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,6 +1,7 @@
 def test_config(cards_cli, db_path):
     assert cards_cli("config") == str(db_path)
 
+
 def test_config_normal_path(db_path, cards_cli_no_redirect):
     cards_cli = cards_cli_no_redirect
     assert cards_cli("config") != str(db_path)

--- a/tests/cli/test_count.py
+++ b/tests/cli/test_count.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.mark.num_cards(3)
 def test_count(cards_cli):
-    assert cards_cli('count') == '3'
+    assert cards_cli("count") == "3"

--- a/tests/cli/test_delete.py
+++ b/tests/cli/test_delete.py
@@ -1,5 +1,6 @@
 import cards
 
+
 def test_delete(cards_db, cards_cli):
     i = cards_db.add_card(cards.Card("foo"))
     cards_cli(f"delete {i}")

--- a/tests/cli/test_errors.py
+++ b/tests/cli/test_errors.py
@@ -1,10 +1,10 @@
 import pytest
 
 
-@pytest.mark.parametrize("command", ["delete 25",
-                                     "start 25",
-                                     "finish 25",
-                                     "update 25 -s foo -o brian"])
+@pytest.mark.parametrize(
+    "command",
+    ["delete 25", "start 25", "finish 25", "update 25 -s foo -o brian"],
+)
 def test_invalid_card_id(cards_db, command, cards_cli):
     out = cards_cli(command)
     assert out == "Error: Invalid card id 25"

--- a/tests/cli/test_finish.py
+++ b/tests/cli/test_finish.py
@@ -1,7 +1,8 @@
 import cards
 
+
 def test_finish(cards_db, cards_cli):
     i = cards_db.add_card(cards.Card("some task"))
     cards_cli(f"finish {i}")
     after = cards_db.get_card(i)
-    assert after.state == 'done'
+    assert after.state == "done"

--- a/tests/cli/test_list.py
+++ b/tests/cli/test_list.py
@@ -3,11 +3,12 @@ import cards
 
 expected_output = """\
 
-  ID   state   owner   summary    
- ──────────────────────────────── 
-  1    todo            some task  
+  ID   state   owner   summary
+ ────────────────────────────────
+  1    todo            some task
   2    todo            another
 """
+
 
 def test_list(cards_db, cards_cli):
     cards_db.add_card(cards.Card("some task"))
@@ -15,9 +16,9 @@ def test_list(cards_db, cards_cli):
     output = cards_cli("list")
     assert output.strip() == expected_output.strip()
 
+
 def test_main(cards_db, cards_cli):
     cards_db.add_card(cards.Card("some task"))
     cards_db.add_card(cards.Card("another"))
     output = cards_cli("")
     assert output.strip() == expected_output.strip()
-

--- a/tests/cli/test_list.py
+++ b/tests/cli/test_list.py
@@ -14,11 +14,15 @@ def test_list(cards_db, cards_cli):
     cards_db.add_card(cards.Card("some task"))
     cards_db.add_card(cards.Card("another"))
     output = cards_cli("list")
-    assert output.strip() == expected_output.strip()
+    for out, exp in zip(output.splitlines(), expected_output.splitlines()):
+        assert out.strip() == exp.strip()
+    # assert output.strip() == expected_output.strip()
 
 
 def test_main(cards_db, cards_cli):
     cards_db.add_card(cards.Card("some task"))
     cards_db.add_card(cards.Card("another"))
     output = cards_cli("")
-    assert output.strip() == expected_output.strip()
+    for out, exp in zip(output.splitlines(), expected_output.splitlines()):
+        assert out.strip() == exp.strip()
+    # assert output.strip() == expected_output.strip()

--- a/tests/cli/test_start.py
+++ b/tests/cli/test_start.py
@@ -1,7 +1,8 @@
 import cards
 
+
 def test_start(cards_db, cards_cli):
     i = cards_db.add_card(cards.Card("some task"))
     cards_cli(f"start {i}")
     after = cards_db.get_card(i)
-    assert after.state == 'in prog'
+    assert after.state == "in prog"

--- a/tests/cli/test_update.py
+++ b/tests/cli/test_update.py
@@ -1,5 +1,6 @@
 import cards
 
+
 def test_update(cards_db, cards_cli):
     i = cards_db.add_card(cards.Card("foo"))
     cards_cli(f"update {i} -o okken -s something")

--- a/tests/cli/test_version.py
+++ b/tests/cli/test_version.py
@@ -1,4 +1,5 @@
 import cards
 
+
 def test_version(cards_cli):
-    assert cards_cli('version') == cards.__version__
+    assert cards_cli("version") == cards.__version__

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
-import pytest
 import cards
+import pytest
 from cards import Card
 
 
@@ -22,15 +22,10 @@ def cards_db(session_cards_db, request, faker):
     db = session_cards_db
     db.delete_all()
     # support for `@pytest.mark.num_cards(<some number>)`
-    faker.seed_instance(101) # random seed
-    m = request.node.get_closest_marker('num_cards')
+    faker.seed_instance(101)  # random seed
+    m = request.node.get_closest_marker("num_cards")
     if m and len(m.args) > 0:
         num_cards = m.args[0]
         for _ in range(num_cards):
-            db.add_card(Card(summary=faker.sentence(),
-                             owner=faker.first_name()))
+            db.add_card(Card(summary=faker.sentence(), owner=faker.first_name()))
     return db
-
-
-
-

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,3 @@ deps =
   pytest-cov
 commands =
   pytest --cov=cards --cov=tests --cov-fail-under=100 {posargs}
-


### PR DESCRIPTION
% `pre-commit autoupdate`
```
[WARNING] The 'rev' field of repo 'https://github.com/psf/black' appears to be a mutable reference (moving tag / branch).  Mutable references are never updated after first install and are not supported.  See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.  Hint: `pre-commit autoupdate` often fixes this.
[https://github.com/pre-commit/pre-commit-hooks] updating v2.5.0 -> v4.4.0
[https://github.com/psf/black] updating stable -> 23.7.0
[https://github.com/codespell-project/codespell] updating v1.16.0 -> v2.2.5
[https://github.com/pycqa/flake8] updating 3.7.9 -> 6.1.0
[https://github.com/asottile/reorder_python_imports] updating v1.9.0 -> v3.10.0
[https://github.com/asottile/pyupgrade] updating v2.0.1 -> v3.10.1
[https://github.com/asottile/add-trailing-comma] updating v1.5.0 -> v3.1.0
```
% `pre-commit run --all-files`